### PR TITLE
Add support for retry_on_conflict for individual updates

### DIFF
--- a/Sources/Elasticsearch/Client/ElasticsearchBulk.swift
+++ b/Sources/Elasticsearch/Client/ElasticsearchBulk.swift
@@ -147,7 +147,7 @@ public class ElasticsearchBulk {
         requestBody.append(10)
 
         // Add the document to the request body followed by a newline character (newline -> 10)
-        let updateDoc = UpdateDoc(doc: doc, docAsUpsert: docAsUpsert)
+        let updateDoc = UpdateDoc(doc: doc, docAsUpsert: docAsUpsert, retryOnConflict: retryOnConflict)
         requestBody.append(try encoder.encode(updateDoc))
         requestBody.append(10)
     }

--- a/Sources/Elasticsearch/Client/ElasticsearchClient+CRUD.swift
+++ b/Sources/Elasticsearch/Client/ElasticsearchClient+CRUD.swift
@@ -1,15 +1,5 @@
 import HTTP
 
-
-public struct UpdateQueryParams: Encodable {
-    // Number of retry attempts (only in 'update' commands)
-    public var retryOnConflict: Int?
-
-    enum CodingKeys: String, CodingKey {
-        case retryOnConflict = "retry_on_conflict"
-    }
-}
-
 /**
  CRUD methods.
  */
@@ -111,12 +101,10 @@ extension ElasticsearchClient {
         retryOnConflict: Int? = nil
     ) -> Future<IndexResponse>{
         let url = ElasticsearchClient.generateURL(path: "/\(index)/\(type)/\(id)/_update", routing: routing, version: version)
-        var body: Data
+        let body: Data
         do {
-            let updateDoc = UpdateDoc(doc: doc, docAsUpsert: docAsUpsert)
-            let queryParams = UpdateQueryParams(retryOnConflict: retryOnConflict)
+            let updateDoc = UpdateDoc(doc: doc, docAsUpsert: docAsUpsert, retryOnConflict: retryOnConflict)
             body = try self.encoder.encode(updateDoc)
-            body.append(try self.encoder.encode(queryParams))
         } catch {
             return worker.future(error: error)
         }
@@ -143,12 +131,10 @@ extension ElasticsearchClient {
         retryOnConflict: Int? = nil
     ) -> Future<IndexResponse>{
         let url = ElasticsearchClient.generateURL(path: "/\(index)/\(type)/\(id)/_update", routing: routing, version: version)
-        var body: Data
+        let body: Data
         do {
-            let updateScript = UpdateScript(script: script)
-            let queryParams = UpdateQueryParams(retryOnConflict: retryOnConflict)
+            let updateScript = UpdateScript(script: script, retryOnConflict: retryOnConflict)
             body = try self.encoder.encode(updateScript)
-            body.append(try self.encoder.encode(queryParams))
         } catch {
             return worker.future(error: error)
         }

--- a/Sources/Elasticsearch/Model/Response/IndexResponse.swift
+++ b/Sources/Elasticsearch/Model/Response/IndexResponse.swift
@@ -7,7 +7,6 @@ public struct IndexResponse: Codable {
     public let result :ResultType
     public let seqNo: Int? = nil
     public let primaryTerm: Int? = nil
-    public let retryOnConflict: Int? = nil
 //    public let routing :String?
 
     public struct Shards: Codable {
@@ -34,6 +33,5 @@ public struct IndexResponse: Codable {
         case result
         case seqNo = "_seq_no"
         case primaryTerm = "_primary_term"
-        case retryOnConflict = "retry_on_conflict"
     }
 }

--- a/Sources/Elasticsearch/Model/Response/IndexResponse.swift
+++ b/Sources/Elasticsearch/Model/Response/IndexResponse.swift
@@ -7,6 +7,7 @@ public struct IndexResponse: Codable {
     public let result :ResultType
     public let seqNo: Int? = nil
     public let primaryTerm: Int? = nil
+    public let retryOnConflict: Int? = nil
 //    public let routing :String?
 
     public struct Shards: Codable {
@@ -33,5 +34,6 @@ public struct IndexResponse: Codable {
         case result
         case seqNo = "_seq_no"
         case primaryTerm = "_primary_term"
+        case retryOnConflict = "retry_on_conflict"
     }
 }

--- a/Sources/Elasticsearch/Model/Update.swift
+++ b/Sources/Elasticsearch/Model/Update.swift
@@ -1,7 +1,7 @@
 public struct UpdateDoc<T: Encodable> : Encodable {
     public let doc: T
     public let docAsUpsert: Bool
-    public var retryOnConflict: Int? = nil
+    public let retryOnConflict: Int?
 
     public enum CodingKeys: String, CodingKey {
         case doc = "doc"
@@ -12,7 +12,7 @@ public struct UpdateDoc<T: Encodable> : Encodable {
 
 public struct UpdateScript : Encodable {
     public let script: Script
-    public var retryOnConflict: Int? = nil
+    public let retryOnConflict: Int?
 
     public enum CodingKeys: String, CodingKey {
         case script = "script"

--- a/Sources/Elasticsearch/Model/Update.swift
+++ b/Sources/Elasticsearch/Model/Update.swift
@@ -1,17 +1,21 @@
 public struct UpdateDoc<T: Encodable> : Encodable {
     public let doc: T
     public let docAsUpsert: Bool
+    public var retryOnConflict: Int? = nil
 
     public enum CodingKeys: String, CodingKey {
         case doc = "doc"
         case docAsUpsert = "doc_as_upsert"
+        case retryOnConflict = "retry_on_conflict"
     }
 }
 
 public struct UpdateScript : Encodable {
     public let script: Script
+    public var retryOnConflict: Int? = nil
 
     public enum CodingKeys: String, CodingKey {
         case script = "script"
+        case retryOnConflict = "retry_on_conflict"
     }
 }

--- a/Tests/ElasticsearchTests/ElasticsearchTests.swift
+++ b/Tests/ElasticsearchTests/ElasticsearchTests.swift
@@ -99,7 +99,7 @@ final class ElasticsearchTests: XCTestCase {
 
                 let script = Script(source: "ctx._source.name = 'maz'")
 
-                response = try es.update(script: script, index: "test", id: fetchedDoc2.id).wait()
+                response = try es.update(script: script, index: "test", id: fetchedDoc2.id, retryOnConflict: 2).wait()
 
 
                 if let fetchedDoc = try es.get(decodeTo: TestModel.self, index: "test", id: fetchedDoc2.id).wait() {


### PR DESCRIPTION
Previously, this was only available for bulk updates but we also
want to be able to retry updates so single doc or update
operations

<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] All tests are passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
